### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 env:
   # Set these
   USERNAME: ${{ github.repository_owner }}


### PR DESCRIPTION
Potential fix for [https://github.com/CodyCBakerPhD/work-history-data/security/code-scanning/3](https://github.com/CodyCBakerPhD/work-history-data/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/update.yml` so all jobs inherit least-privilege defaults.  
Best single fix without changing behavior: add:

- `contents: read` (minimal baseline recommended by CodeQL)

Place it near the top of the workflow (e.g., after `on:` block and before `env:`). This satisfies the scanner and documents intended token scope while not altering existing custom-secret-based push behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
