### PR TITLE
Always install historia in update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -62,6 +62,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Get exact Python version
+        id: python-version
+        run: echo "value=$(python --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Restore pip cache
         id: pip-cache
         uses: actions/cache@v5
@@ -69,9 +73,10 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.local
-          key: pip-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ env.HISTORIA_SPEC }}
+          key: pip-${{ runner.os }}-py${{ steps.python-version.outputs.value }}-${{ env.HISTORIA_SPEC }}
 
       - name: Install historia
+        if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install --user "$HISTORIA_SPEC"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -72,7 +72,6 @@ jobs:
           key: pip-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ env.HISTORIA_SPEC }}
 
       - name: Install historia
-        if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install --user "$HISTORIA_SPEC"


### PR DESCRIPTION
## Summary
Removed the conditional cache check that was skipping the historia installation step when pip cache was hit, ensuring historia is always installed regardless of cache state.

## Key Changes
- Removed the `if: steps.pip-cache.outputs.cache-hit != 'true'` condition from the "Install historia" step in the update workflow
- This ensures the historia package is installed on every workflow run, not just when the pip cache is missed

## Implementation Details
Previously, the historia installation was skipped when the pip cache was successfully restored. This change makes the installation unconditional, which is important for ensuring the workflow always has the latest or correct version of historia available, even when dependencies are cached.

https://claude.ai/code/session_014wULCmyyrMo3QH3BtEgC5r