### PR TITLE
Use exact Python version in pip cache key

### DIFF
--- a/.github/workflows/move-done-to-history.yml
+++ b/.github/workflows/move-done-to-history.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Get exact Python version
+        id: python-version
+        run: echo "value=$(python --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Restore pip cache
         id: pip-cache
         uses: actions/cache@v5
@@ -30,7 +34,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.local
-          key: pip-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ env.HISTORIA_SPEC }}
+          key: pip-${{ runner.os }}-py${{ steps.python-version.outputs.value }}-${{ env.HISTORIA_SPEC }}
 
       - name: Install historia
         if: steps.pip-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
Updated the pip cache key generation in the GitHub Actions workflow to use the exact installed Python version instead of the environment variable, ensuring more precise cache matching.

## Key Changes
- Added a new step to extract the exact Python version from `python --version` output
- Updated the pip cache key to use the dynamically determined Python version (`steps.python-version.outputs.value`) instead of the `env.PYTHON_VERSION` variable
- This ensures the cache key reflects the actual Python version being used, improving cache hit accuracy

## Implementation Details
The exact Python version is captured by running `python --version | cut -d' ' -f2` and storing it in the step output `value`. This approach handles cases where the environment variable might differ from the actual installed version, providing more reliable cache invalidation when Python versions change.

https://claude.ai/code/session_013wBYswzagfXQTmgeDqz8Go